### PR TITLE
Use None vs empty json by default

### DIFF
--- a/apexdevkit/http/httpx.py
+++ b/apexdevkit/http/httpx.py
@@ -65,7 +65,7 @@ class HttpxConfig(Mapping[str, Any]):
     endpoint: str = ""
     headers: JsonDict = field(default_factory=JsonDict)
     params: JsonDict = field(default_factory=JsonDict)
-    json: JsonDict = field(default_factory=JsonDict)
+    json: JsonDict | None = None
 
     def with_endpoint(self, endpoint: str) -> HttpxConfig:
         return HttpxConfig(
@@ -104,7 +104,7 @@ class HttpxConfig(Mapping[str, Any]):
             "url": self.endpoint,
             "headers": dict(self.headers),
             "params": dict(self.params),
-            "json": dict(self.json),
+            "json": dict(self.json) if self.json is not None else None,
         }
 
     def __len__(self) -> int:

--- a/tests/http/cassettes/test_httpx/test_should_delete.yaml
+++ b/tests/http/cassettes/test_httpx/test_should_delete.yaml
@@ -1,6 +1,6 @@
 interactions:
 - request:
-    body: '{}'
+    body: ''
     headers:
       accept:
       - '*/*'
@@ -8,10 +8,6 @@ interactions:
       - gzip, deflate
       connection:
       - keep-alive
-      content-length:
-      - '2'
-      content-type:
-      - application/json
       host:
       - httpbin.org
       user-agent:
@@ -20,12 +16,11 @@ interactions:
     uri: http://httpbin.org/delete
   response:
     body:
-      string: "{\n  \"args\": {}, \n  \"data\": \"{}\", \n  \"files\": {}, \n  \"form\":
+      string: "{\n  \"args\": {}, \n  \"data\": \"\", \n  \"files\": {}, \n  \"form\":
         {}, \n  \"headers\": {\n    \"Accept\": \"*/*\", \n    \"Accept-Encoding\":
-        \"gzip, deflate\", \n    \"Content-Length\": \"2\", \n    \"Content-Type\":
-        \"application/json\", \n    \"Host\": \"httpbin.org\", \n    \"User-Agent\":
-        \"hogwarts\", \n    \"X-Amzn-Trace-Id\": \"Root=1-6632616e-1f43bcf1173f75602c8d787c\"\n
-        \ }, \n  \"json\": {}, \n  \"origin\": \"95.104.119.242\", \n  \"url\": \"http://httpbin.org/delete\"\n}\n"
+        \"gzip, deflate\", \n    \"Host\": \"httpbin.org\", \n    \"User-Agent\":
+        \"hogwarts\", \n    \"X-Amzn-Trace-Id\": \"Root=1-66ccef7f-43a9ebaa7480c62a48ccf73b\"\n
+        \ }, \n  \"json\": null, \n  \"origin\": \"5.178.149.253\", \n  \"url\": \"http://httpbin.org/delete\"\n}\n"
     headers:
       Access-Control-Allow-Credentials:
       - 'true'
@@ -34,11 +29,11 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '428'
+      - '358'
       Content-Type:
       - application/json
       Date:
-      - Wed, 01 May 2024 15:36:15 GMT
+      - Mon, 26 Aug 2024 21:11:29 GMT
       Server:
       - gunicorn/19.9.0
     status:

--- a/tests/http/cassettes/test_httpx/test_should_get.yaml
+++ b/tests/http/cassettes/test_httpx/test_should_get.yaml
@@ -1,6 +1,6 @@
 interactions:
 - request:
-    body: '{}'
+    body: ''
     headers:
       accept:
       - '*/*'
@@ -8,10 +8,6 @@ interactions:
       - gzip, deflate
       connection:
       - keep-alive
-      content-length:
-      - '2'
-      content-type:
-      - application/json
       host:
       - httpbin.org
       user-agent:
@@ -21,23 +17,22 @@ interactions:
   response:
     body:
       string: "{\n  \"args\": {}, \n  \"headers\": {\n    \"Accept\": \"*/*\", \n
-        \   \"Accept-Encoding\": \"gzip, deflate\", \n    \"Content-Length\": \"2\",
-        \n    \"Content-Type\": \"application/json\", \n    \"Host\": \"httpbin.org\",
-        \n    \"User-Agent\": \"hogwarts\", \n    \"X-Amzn-Trace-Id\": \"Root=1-6632616d-3504fa1c0921a70262379bf4\"\n
-        \ }, \n  \"origin\": \"95.104.119.242\", \n  \"url\": \"http://httpbin.org/get\"\n}\n"
+        \   \"Accept-Encoding\": \"gzip, deflate\", \n    \"Host\": \"httpbin.org\",
+        \n    \"User-Agent\": \"hogwarts\", \n    \"X-Amzn-Trace-Id\": \"Root=1-66ccef7b-0faf88ad043a1610159a00a2\"\n
+        \ }, \n  \"origin\": \"5.178.149.253\", \n  \"url\": \"http://httpbin.org/get\"\n}\n"
     headers:
       Access-Control-Allow-Credentials:
       - 'true'
       Access-Control-Allow-Origin:
       - '*'
       Connection:
-      - close
+      - keep-alive
       Content-Length:
-      - '362'
+      - '292'
       Content-Type:
       - application/json
       Date:
-      - Wed, 01 May 2024 15:36:14 GMT
+      - Mon, 26 Aug 2024 21:11:23 GMT
       Server:
       - gunicorn/19.9.0
     status:

--- a/tests/http/cassettes/test_httpx/test_should_get_with_params.yaml
+++ b/tests/http/cassettes/test_httpx/test_should_get_with_params.yaml
@@ -1,6 +1,6 @@
 interactions:
 - request:
-    body: '{}'
+    body: ''
     headers:
       accept:
       - '*/*'
@@ -8,10 +8,6 @@ interactions:
       - gzip, deflate
       connection:
       - keep-alive
-      content-length:
-      - '2'
-      content-type:
-      - application/json
       host:
       - httpbin.org
       user-agent:
@@ -22,9 +18,8 @@ interactions:
     body:
       string: "{\n  \"args\": {\n    \"Color\": \"Yellow\"\n  }, \n  \"headers\":
         {\n    \"Accept\": \"*/*\", \n    \"Accept-Encoding\": \"gzip, deflate\",
-        \n    \"Content-Length\": \"2\", \n    \"Content-Type\": \"application/json\",
         \n    \"Host\": \"httpbin.org\", \n    \"User-Agent\": \"hogwarts\", \n    \"X-Amzn-Trace-Id\":
-        \"Root=1-66326376-71eeb1743efc8d0c678be874\"\n  }, \n  \"origin\": \"95.104.119.242\",
+        \"Root=1-66ccef7b-24c30bd92c2238fc171f1daa\"\n  }, \n  \"origin\": \"5.178.149.253\",
         \n  \"url\": \"http://httpbin.org/get?Color=Yellow\"\n}\n"
     headers:
       Access-Control-Allow-Credentials:
@@ -32,13 +27,13 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Connection:
-      - close
+      - keep-alive
       Content-Length:
-      - '400'
+      - '330'
       Content-Type:
       - application/json
       Date:
-      - Wed, 01 May 2024 15:44:54 GMT
+      - Mon, 26 Aug 2024 21:11:26 GMT
       Server:
       - gunicorn/19.9.0
     status:

--- a/tests/http/cassettes/test_httpx/test_should_patch.yaml
+++ b/tests/http/cassettes/test_httpx/test_should_patch.yaml
@@ -24,8 +24,8 @@ interactions:
         \n  \"files\": {}, \n  \"form\": {}, \n  \"headers\": {\n    \"Accept\": \"*/*\",
         \n    \"Accept-Encoding\": \"gzip, deflate\", \n    \"Content-Length\": \"19\",
         \n    \"Content-Type\": \"application/json\", \n    \"Host\": \"httpbin.org\",
-        \n    \"User-Agent\": \"hogwarts\", \n    \"X-Amzn-Trace-Id\": \"Root=1-6632616e-01fb25f570d439342891a00a\"\n
-        \ }, \n  \"json\": {\n    \"Harry\": \"Potter\"\n  }, \n  \"origin\": \"95.104.119.242\",
+        \n    \"User-Agent\": \"hogwarts\", \n    \"X-Amzn-Trace-Id\": \"Root=1-66ccef7f-785ee6d956e4be6d3ac66de4\"\n
+        \ }, \n  \"json\": {\n    \"Harry\": \"Potter\"\n  }, \n  \"origin\": \"5.178.149.253\",
         \n  \"url\": \"http://httpbin.org/patch\"\n}\n"
     headers:
       Access-Control-Allow-Credentials:
@@ -35,11 +35,11 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '474'
+      - '473'
       Content-Type:
       - application/json
       Date:
-      - Wed, 01 May 2024 15:36:14 GMT
+      - Mon, 26 Aug 2024 21:11:27 GMT
       Server:
       - gunicorn/19.9.0
     status:

--- a/tests/http/cassettes/test_httpx/test_should_post.yaml
+++ b/tests/http/cassettes/test_httpx/test_should_post.yaml
@@ -24,8 +24,8 @@ interactions:
         \n  \"files\": {}, \n  \"form\": {}, \n  \"headers\": {\n    \"Accept\": \"*/*\",
         \n    \"Accept-Encoding\": \"gzip, deflate\", \n    \"Content-Length\": \"19\",
         \n    \"Content-Type\": \"application/json\", \n    \"Host\": \"httpbin.org\",
-        \n    \"User-Agent\": \"hogwarts\", \n    \"X-Amzn-Trace-Id\": \"Root=1-6632616d-695cd5dc52dabdcf5aa05065\"\n
-        \ }, \n  \"json\": {\n    \"Harry\": \"Potter\"\n  }, \n  \"origin\": \"95.104.119.242\",
+        \n    \"User-Agent\": \"hogwarts\", \n    \"X-Amzn-Trace-Id\": \"Root=1-66ccef7a-52e8f09f28af2cba0ff4a227\"\n
+        \ }, \n  \"json\": {\n    \"Harry\": \"Potter\"\n  }, \n  \"origin\": \"5.178.149.253\",
         \n  \"url\": \"http://httpbin.org/post\"\n}\n"
     headers:
       Access-Control-Allow-Credentials:
@@ -35,11 +35,11 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '473'
+      - '472'
       Content-Type:
       - application/json
       Date:
-      - Wed, 01 May 2024 15:36:13 GMT
+      - Mon, 26 Aug 2024 21:11:23 GMT
       Server:
       - gunicorn/19.9.0
     status:

--- a/tests/http/cassettes/test_httpx/test_should_put.yaml
+++ b/tests/http/cassettes/test_httpx/test_should_put.yaml
@@ -24,8 +24,8 @@ interactions:
         \n  \"files\": {}, \n  \"form\": {}, \n  \"headers\": {\n    \"Accept\": \"*/*\",
         \n    \"Accept-Encoding\": \"gzip, deflate\", \n    \"Content-Length\": \"19\",
         \n    \"Content-Type\": \"application/json\", \n    \"Host\": \"httpbin.org\",
-        \n    \"User-Agent\": \"hogwarts\", \n    \"X-Amzn-Trace-Id\": \"Root=1-666c0972-35f599a33a8b776240f87918\"\n
-        \ }, \n  \"json\": {\n    \"Harry\": \"Potter\"\n  }, \n  \"origin\": \"95.104.119.242\",
+        \n    \"User-Agent\": \"hogwarts\", \n    \"X-Amzn-Trace-Id\": \"Root=1-66ccef82-5860df01036369206eb93d74\"\n
+        \ }, \n  \"json\": {\n    \"Harry\": \"Potter\"\n  }, \n  \"origin\": \"5.178.149.253\",
         \n  \"url\": \"http://httpbin.org/put\"\n}\n"
     headers:
       Access-Control-Allow-Credentials:
@@ -35,11 +35,11 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '472'
+      - '471'
       Content-Type:
       - application/json
       Date:
-      - Fri, 14 Jun 2024 09:12:18 GMT
+      - Mon, 26 Aug 2024 21:11:30 GMT
       Server:
       - gunicorn/19.9.0
     status:


### PR DESCRIPTION
As is, empty json is passed to httpx by default.
This causes errors for servers that
do not ignore GET request body.

To be, unless user explicitly uses with_json,
we should give None as an argument to httpx
indicating that we do not wish to use request body.