### PR TITLE
Disable many key duplication check

### DIFF
--- a/apexdevkit/repository/in_memory.py
+++ b/apexdevkit/repository/in_memory.py
@@ -199,13 +199,9 @@ class _ManyKeyRepository(RepositoryBase[ItemT]):
 
     def _ensure_does_not_exist(self, new: ItemT) -> None:
         for existing in self:
-            error = ExistsError(existing)
-
             for key in self.keys:
                 if key(new) == key(existing):
-                    error.with_duplicate(key)
-
-            error.fire()
+                    ExistsError(existing).with_duplicate(key).fire()
 
     def _pk(self, item: ItemT) -> str:
         return self.keys[0](item)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "apexdevkit"
-version = "1.16.5"
+version = "1.17.0"
 description = "Apex Development Tools for python."
 authors = ["Apex Dev <dev@apex.ge>"]
 readme = "README.md"

--- a/tests/repository/test_in_memory.py
+++ b/tests/repository/test_in_memory.py
@@ -101,6 +101,7 @@ def test_should_not_duplicate() -> None:
     assert str(cm.value) == f"code<{company.code}>"
 
 
+@pytest.mark.skip(reason="Removed intentionally")
 def test_should_not_not_duplicate_many_fields() -> None:
     company = _Company.fake()
     repository = (


### PR DESCRIPTION
It is impossible to distinguish between duplication and uniqueness criteria.
So, for now we disable multi key duplication check to avoid problems down the line.
Ideally we want to have this functionality provided in the future.