### PR TITLE
Initialize DependableBuilder from callable

### DIFF
--- a/apexdevkit/fastapi/dependable.py
+++ b/apexdevkit/fastapi/dependable.py
@@ -4,6 +4,7 @@ from typing import Annotated, Any, Callable, Protocol
 from fastapi import Depends, Path
 from fastapi.requests import Request
 
+from apexdevkit.annotation import deprecated
 from apexdevkit.error import ApiError, DoesNotExistError
 from apexdevkit.fastapi import RestfulServiceBuilder
 from apexdevkit.fastapi.name import RestfulName
@@ -82,10 +83,34 @@ class InfraDependency:
         return Annotated[RestfulServiceBuilder, Depends(_)]
 
 
+_BuilderCallable = Callable[..., RestfulServiceBuilder]
+
+
+@dataclass(frozen=True)
+class BuilderCallableDependency:
+    create_builder: _BuilderCallable
+
+    def as_dependable(self) -> type[RestfulServiceBuilder]:
+        def _() -> RestfulServiceBuilder:
+            return self.create_builder()
+
+        return Annotated[RestfulServiceBuilder, Depends(_)]
+
+
 @dataclass(frozen=True)
 class DependableBuilder:
     dependency: _Dependency | None = None
 
+    @classmethod
+    def from_callable(cls, value: _BuilderCallable) -> "DependableBuilder":
+        return DependableBuilder(BuilderCallableDependency(value))
+
+    @deprecated(
+        """
+        DependableBuilder().from_infra() is deprecated,
+        use DependencyBuilder.from_callable() instead
+        """
+    )
     def from_infra(self, value: RestfulServiceBuilder) -> "DependableBuilder":
         return DependableBuilder(InfraDependency(value))
 

--- a/tests/fastapi/test_dependable.py
+++ b/tests/fastapi/test_dependable.py
@@ -1,4 +1,3 @@
-from typing import Any, Callable
 from unittest.mock import MagicMock
 
 import pytest
@@ -12,19 +11,6 @@ from apexdevkit.fastapi.router import Dependency, RestfulRouter
 from apexdevkit.http import Httpx
 from apexdevkit.testing import RestCollection
 from tests.fastapi.sample_api import AppleFields, PriceFields
-
-
-@pytest.fixture
-def user() -> Any:
-    return "A"
-
-
-@pytest.fixture
-def extract_user(user: Any) -> Callable[..., Any]:
-    def _() -> Any:
-        return user
-
-    return _
 
 
 @pytest.fixture
@@ -70,14 +56,12 @@ def resource(dependency: Dependency) -> RestCollection:
     )
 
 
-def test_should_build_dependable_with_user(
-    user: Any,
-    extract_user: Callable[..., Any],
-) -> None:
+def test_should_build_dependable_with_user() -> None:
+    user = "A"
     infra = MagicMock(spec=RestfulServiceBuilder)
 
     (
-        resource(DependableBuilder.from_callable(lambda: infra).with_user(extract_user))
+        resource(DependableBuilder.from_callable(lambda: infra).with_user(lambda: user))
         .read_all()
         .ensure()
     )

--- a/tests/fastapi/test_dependable.py
+++ b/tests/fastapi/test_dependable.py
@@ -62,15 +62,13 @@ def test_should_build_dependable_with_user(faker: Faker) -> None:
     builder = MagicMock(spec=RestfulServiceBuilder)
 
     (
-        resource(
-            DependableBuilder.from_callable(lambda: builder).with_user(lambda: user)
-        )
+        resource(DependableBuilder.from_callable(builder).with_user(lambda: user))
         .read_all()
         .ensure()
     )
 
-    builder.with_user.assert_called_once_with(user)
-    builder.with_user().build.assert_called_once()
+    builder().with_user.assert_called_once_with(user)
+    builder().with_user().build.assert_called_once()
 
 
 def test_should_build_dependable_with_parent(

--- a/tests/fastapi/test_dependable.py
+++ b/tests/fastapi/test_dependable.py
@@ -59,16 +59,18 @@ def resource(dependency: Dependency) -> RestCollection:
 
 def test_should_build_dependable_with_user(faker: Faker) -> None:
     user = faker.name()
-    infra = MagicMock(spec=RestfulServiceBuilder)
+    builder = MagicMock(spec=RestfulServiceBuilder)
 
     (
-        resource(DependableBuilder.from_callable(lambda: infra).with_user(lambda: user))
+        resource(
+            DependableBuilder.from_callable(lambda: builder).with_user(lambda: user)
+        )
         .read_all()
         .ensure()
     )
 
-    infra.with_user.assert_called_once_with(user)
-    infra.with_user().build.assert_called_once()
+    builder.with_user.assert_called_once_with(user)
+    builder.with_user().build.assert_called_once()
 
 
 def test_should_build_dependable_with_parent(

--- a/tests/fastapi/test_dependable.py
+++ b/tests/fastapi/test_dependable.py
@@ -76,17 +76,18 @@ def test_should_build_dependable_with_parent(
     parent: RestfulName,
     child: RestfulName,
 ) -> None:
-    infra = MagicMock(spec=RestfulServiceBuilder)
+    builder = MagicMock(spec=RestfulServiceBuilder)
+
     (
-        resource(DependableBuilder.from_callable(lambda: infra).with_parent(parent))
+        resource(DependableBuilder.from_callable(builder).with_parent(parent))
         .sub_resource(identifier)
         .sub_resource(child.singular)
         .read_all()
         .ensure()
     )
 
-    infra.with_parent.assert_called_once_with(identifier)
-    infra.with_parent().build.assert_called_once()
+    builder().with_parent.assert_called_once_with(identifier)
+    builder().with_parent().build.assert_called_once()
 
 
 def test_should_not_build_dependable_when_no_parent(
@@ -94,11 +95,11 @@ def test_should_not_build_dependable_when_no_parent(
     parent: RestfulName,
     child: RestfulName,
 ) -> None:
-    infra = MagicMock(spec=RestfulServiceBuilder)
-    infra.with_parent.side_effect = DoesNotExistError(identifier)
+    builder = MagicMock(spec=RestfulServiceBuilder)
+    builder().with_parent.side_effect = DoesNotExistError(identifier)
 
     (
-        resource(DependableBuilder.from_callable(lambda: infra).with_parent(parent))
+        resource(DependableBuilder.from_callable(builder).with_parent(parent))
         .sub_resource(identifier)
         .sub_resource(child.singular)
         .read_all()

--- a/tests/fastapi/test_dependable.py
+++ b/tests/fastapi/test_dependable.py
@@ -14,7 +14,7 @@ from apexdevkit.testing import RestCollection
 from tests.fastapi.sample_api import AppleFields, PriceFields
 
 
-def parent_resource(dependency: Dependency) -> RestCollection:
+def resource(dependency: Dependency) -> RestCollection:
     return RestCollection(
         name=RestfulName("apple"),
         http=Httpx(
@@ -77,9 +77,7 @@ def test_should_build_dependable_with_user(
     infra = MagicMock(spec=RestfulServiceBuilder)
 
     (
-        parent_resource(
-            DependableBuilder.from_callable(lambda: infra).with_user(extract_user)
-        )
+        resource(DependableBuilder.from_callable(lambda: infra).with_user(extract_user))
         .read_all()
         .ensure()
     )
@@ -95,9 +93,7 @@ def test_should_build_dependable_with_parent(
 ) -> None:
     infra = MagicMock(spec=RestfulServiceBuilder)
     (
-        parent_resource(
-            DependableBuilder.from_callable(lambda: infra).with_parent(parent)
-        )
+        resource(DependableBuilder.from_callable(lambda: infra).with_parent(parent))
         .sub_resource(identifier)
         .sub_resource(child.singular)
         .read_all()
@@ -115,10 +111,9 @@ def test_should_not_build_dependable_when_no_parent(
 ) -> None:
     infra = MagicMock(spec=RestfulServiceBuilder)
     infra.with_parent.side_effect = DoesNotExistError(identifier)
+
     (
-        parent_resource(
-            DependableBuilder.from_callable(lambda: infra).with_parent(parent)
-        )
+        resource(DependableBuilder.from_callable(lambda: infra).with_parent(parent))
         .sub_resource(identifier)
         .sub_resource(child.singular)
         .read_all()

--- a/tests/fastapi/test_dependable.py
+++ b/tests/fastapi/test_dependable.py
@@ -1,6 +1,7 @@
 from unittest.mock import MagicMock
 
 import pytest
+from faker import Faker
 from starlette.testclient import TestClient
 
 from apexdevkit.error import DoesNotExistError
@@ -56,8 +57,8 @@ def resource(dependency: Dependency) -> RestCollection:
     )
 
 
-def test_should_build_dependable_with_user() -> None:
-    user = "A"
+def test_should_build_dependable_with_user(faker: Faker) -> None:
+    user = faker.name()
     infra = MagicMock(spec=RestfulServiceBuilder)
 
     (

--- a/tests/fastapi/test_dependable.py
+++ b/tests/fastapi/test_dependable.py
@@ -14,26 +14,6 @@ from apexdevkit.testing import RestCollection
 from tests.fastapi.sample_api import AppleFields, PriceFields
 
 
-def resource_with_dependency(dependency: Dependency) -> RestCollection:
-    return RestCollection(
-        name=RestfulName("apple"),
-        http=Httpx(
-            TestClient(
-                FastApiBuilder()
-                .with_route(
-                    apples=RestfulRouter()
-                    .with_name(RestfulName("apple"))
-                    .with_fields(AppleFields())
-                    .with_dependency(dependency)
-                    .default()
-                    .build()
-                )
-                .build()
-            )
-        ),
-    )
-
-
 def parent_resource(dependency: Dependency) -> RestCollection:
     return RestCollection(
         name=RestfulName("apple"),
@@ -44,6 +24,7 @@ def parent_resource(dependency: Dependency) -> RestCollection:
                     apples=RestfulRouter()
                     .with_name(RestfulName("apple"))
                     .with_fields(AppleFields())
+                    .with_dependency(dependency)
                     .with_sub_resource(
                         prices=RestfulRouter()
                         .with_name(RestfulName("price"))
@@ -52,6 +33,7 @@ def parent_resource(dependency: Dependency) -> RestCollection:
                         .default()
                         .build()
                     )
+                    .default()
                     .build()
                 )
                 .build()
@@ -95,7 +77,7 @@ def test_should_build_dependable_with_user(
     infra = MagicMock(spec=RestfulServiceBuilder)
 
     (
-        resource_with_dependency(
+        parent_resource(
             DependableBuilder.from_callable(lambda: infra).with_user(extract_user)
         )
         .read_all()

--- a/tests/fastapi/test_dependable.py
+++ b/tests/fastapi/test_dependable.py
@@ -15,11 +15,6 @@ from tests.fastapi.sample_api import AppleFields, PriceFields
 
 
 @pytest.fixture
-def parent_id() -> str:
-    return "id"
-
-
-@pytest.fixture
 def parent() -> RestfulName:
     return RestfulName("apple")
 

--- a/tests/fastapi/test_dependable.py
+++ b/tests/fastapi/test_dependable.py
@@ -12,24 +12,24 @@ from apexdevkit.http import Httpx
 from apexdevkit.testing import RestCollection
 from tests.fastapi.sample_api import AppleFields, PriceFields
 
-PARENT = RestfulName("apple")
-CHILD = RestfulName("price")
+_PARENT = RestfulName("apple")
+_CHILD = RestfulName("price")
 
 
-def resource(dependency: Dependency) -> RestCollection:
+def _resource(dependency: Dependency) -> RestCollection:
     return RestCollection(
-        name=PARENT,
+        name=_PARENT,
         http=Httpx(
             TestClient(
                 FastApiBuilder()
                 .with_route(
                     apples=RestfulRouter()
-                    .with_name(PARENT)
+                    .with_name(_PARENT)
                     .with_fields(AppleFields())
                     .with_dependency(dependency)
                     .with_sub_resource(
                         prices=RestfulRouter()
-                        .with_name(CHILD)
+                        .with_name(_CHILD)
                         .with_fields(PriceFields())
                         .with_dependency(dependency)
                         .default()
@@ -49,7 +49,7 @@ def test_should_build_dependable_with_user(faker: Faker) -> None:
     builder = MagicMock(spec=RestfulServiceBuilder)
 
     (
-        resource(DependableBuilder.from_callable(builder).with_user(lambda: user))
+        _resource(DependableBuilder.from_callable(builder).with_user(lambda: user))
         .read_all()
         .ensure()
     )
@@ -63,9 +63,9 @@ def test_should_build_dependable_with_parent(faker: Faker) -> None:
     builder = MagicMock(spec=RestfulServiceBuilder)
 
     (
-        resource(DependableBuilder.from_callable(builder).with_parent(PARENT))
+        _resource(DependableBuilder.from_callable(builder).with_parent(_PARENT))
         .sub_resource(parent_id)
-        .sub_resource(CHILD.singular)
+        .sub_resource(_CHILD.singular)
         .read_all()
         .ensure()
         .success()
@@ -81,15 +81,15 @@ def test_should_not_build_dependable_when_no_parent(faker: Faker) -> None:
     builder().with_parent.side_effect = DoesNotExistError(parent_id)
 
     (
-        resource(DependableBuilder.from_callable(builder).with_parent(PARENT))
+        _resource(DependableBuilder.from_callable(builder).with_parent(_PARENT))
         .sub_resource(parent_id)
-        .sub_resource(CHILD.singular)
+        .sub_resource(_CHILD.singular)
         .read_all()
         .ensure()
         .fail()
         .with_code(404)
         .and_message(
-            f"An item<{PARENT.singular.capitalize()}> "
+            f"An item<{_PARENT.singular.capitalize()}> "
             f"with id<{parent_id}> does not exist."
         )
     )

--- a/tests/fastapi/test_dependable.py
+++ b/tests/fastapi/test_dependable.py
@@ -14,34 +14,6 @@ from apexdevkit.testing import RestCollection
 from tests.fastapi.sample_api import AppleFields, PriceFields
 
 
-def resource(dependency: Dependency) -> RestCollection:
-    return RestCollection(
-        name=RestfulName("apple"),
-        http=Httpx(
-            TestClient(
-                FastApiBuilder()
-                .with_route(
-                    apples=RestfulRouter()
-                    .with_name(RestfulName("apple"))
-                    .with_fields(AppleFields())
-                    .with_dependency(dependency)
-                    .with_sub_resource(
-                        prices=RestfulRouter()
-                        .with_name(RestfulName("price"))
-                        .with_fields(PriceFields())
-                        .with_dependency(dependency)
-                        .default()
-                        .build()
-                    )
-                    .default()
-                    .build()
-                )
-                .build()
-            )
-        ),
-    )
-
-
 @pytest.fixture
 def user() -> Any:
     return "A"
@@ -68,6 +40,34 @@ def parent() -> RestfulName:
 @pytest.fixture
 def child() -> RestfulName:
     return RestfulName("price")
+
+
+def resource(dependency: Dependency) -> RestCollection:
+    return RestCollection(
+        name=RestfulName("apple"),
+        http=Httpx(
+            TestClient(
+                FastApiBuilder()
+                .with_route(
+                    apples=RestfulRouter()
+                    .with_name(RestfulName("apple"))
+                    .with_fields(AppleFields())
+                    .with_dependency(dependency)
+                    .with_sub_resource(
+                        prices=RestfulRouter()
+                        .with_name(RestfulName("price"))
+                        .with_fields(PriceFields())
+                        .with_dependency(dependency)
+                        .default()
+                        .build()
+                    )
+                    .default()
+                    .build()
+                )
+                .build()
+            )
+        ),
+    )
 
 
 def test_should_build_dependable_with_user(


### PR DESCRIPTION
In order to avoid race condition between requests, we need service builder to be either immutable,
or created a new for each request. We went with the "create per request" approach.